### PR TITLE
fix - change event shouldn't be triggered when not caused by user

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@
 Package.describe({
     name: 'vazco:universe-selectize',
     summary: 'Universe select input standalone - with the appearance as selectize. It is for use without autoform.',
-    version: '0.1.10',
+    version: '0.1.11',
     git: 'https://github.com/vazco/meteor-universe-selectize.git'
 });
 


### PR DESCRIPTION
I followed logic carefully, moved trigger call from autorun to all places where we set reactive var that this autorun depended on, except cases when not caused by user (onRendered, getOptionsFromMethod) Works well for me now.
