### PR TITLE
fix error when label is a Number

### DIFF
--- a/universe-selectize.js
+++ b/universe-selectize.js
@@ -317,7 +317,7 @@ UniSelectize.prototype.getItemsUnselectedFiltered = function () {
     var searchText = this.searchText.get();
 
     return _.filter(items, function (item) {
-        if (item.label && item.label.search(new RegExp(searchText, 'i')) !== -1) {
+        if (item.label && typeof(item.label) == 'string' && item.label.search(new RegExp(searchText, 'i')) !== -1) {
             return true;
         }
         return false;


### PR DESCRIPTION
There is an error when on .search(regexp) when label is a Number type.

f.i. the error occurs when you use it for autoform (https://github.com/vazco/meteor-universe-autoform-select):
```
items: {
    type: [Number],
    autoform: {
      type: 'universe-select',
      options: options, //[{label:stringType, value:numberType}]
      afFieldInput: {
        multiple: true
      }
    }
  }
```
universe-select is expecting a String for labels. But if the form already contains a selected items and their values not in the options array a value field will be assigned to the label. After you try to remove item you'll get an error:
```
Error: Exception in template helper:
TypeError: item.label.search is not a function
```
Since Number doesn't have a 'search' method